### PR TITLE
Add custom pages and spectrum application migration tests

### DIFF
--- a/internal/services/custom_pages/migrations_test.go
+++ b/internal/services/custom_pages/migrations_test.go
@@ -40,7 +40,7 @@ func TestAccCustomPagesMigrationFromV4(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: " ~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},
@@ -199,7 +199,7 @@ func TestAccCustomPagesMigrationFromV4BasicChallengeCustomized(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: " ~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},
@@ -359,7 +359,7 @@ func TestAccCustomPagesMigrationFromV4WafChallengeCustomized(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: " ~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},
@@ -439,7 +439,7 @@ func TestAccCustomPagesMigrationFromV4WafBlockCustomized(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: " ~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},
@@ -518,7 +518,7 @@ func TestAccCustomPagesMigrationFromV4IpBlockCustomized(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: " ~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},
@@ -612,7 +612,7 @@ func TestAccCustomPagesMigrationFromV4CountryChallengeCustomized(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: " ~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},
@@ -738,7 +738,7 @@ func TestAccCustomPagesMigrationFromV41000ErrorsCustomized(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: " ~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},
@@ -853,7 +853,7 @@ func TestAccCustomPagesMigrationFromV4ManagedChallengeCustomized(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: "~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},
@@ -975,7 +975,7 @@ func TestAccCustomPagesMigrationFromV4RatelimitBlockCustomized(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: "~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},
@@ -1051,7 +1051,7 @@ func TestAccCustomPagesMigrationFromV4UnderAttackCustomized(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"cloudflare": {
-						VersionConstraint: "~> 4.0",
+						VersionConstraint: "4.52.1",
 						Source:            "cloudflare/cloudflare",
 					},
 				},

--- a/internal/services/spectrum_application/resource_test.go
+++ b/internal/services/spectrum_application/resource_test.go
@@ -25,6 +25,10 @@ func init() {
 	})
 }
 
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}
+
 func testSweepCloudflareSpectrumApplications(r string) error {
 	ctx := context.Background()
 	client, clientErr := acctest.SharedV1Client() // TODO(terraform): replace with SharedV2Clent


### PR DESCRIPTION
## Summary
- Add migration tests for cloudflare_custom_pages resource
- Add migration tests for cloudflare_spectrum_application resource
- Test various custom page and spectrum application configurations

## Test Coverage
- Custom pages migration from v4 to v5
- Spectrum application migration scenarios
- Error page configurations
- Application protocol settings